### PR TITLE
Added Payment verification

### DIFF
--- a/src/controllers/payment.controller.js
+++ b/src/controllers/payment.controller.js
@@ -1,9 +1,10 @@
 import razorpay from './../config/razorpay.config.js';
 import asyncHandler from "../utils/asyncHandler.js"
 import CustomError from "../utils/CustomError.js"
+import verifyPayment from "../utils/verifyPayment.js"
 
 export const generatepayment = asyncHandler( async (req, res) => {
-    const { amount } = req.body
+    const { amount ,razorpay_payment_id, razorpay_signature } = req.body
     const options = {
         amount: amount,
         currency: "INR",
@@ -13,12 +14,21 @@ export const generatepayment = asyncHandler( async (req, res) => {
     const order = await razorpay.orders.create(options)
 
     if (!order) {
-        throw new CustomError("UNable to generate order", 400)
+        throw new CustomError("Unable to generate order", 400)
     }
+
+    const paymentData = {
+        razorpay_order_id: order.id,
+        razorpay_payment_id,
+        razorpay_signature: razorpay_signature,
+      };
+    
+    const paymentStatus = await verifyPayment(paymentData);
 
     res.status(200).json({
         success: true,
         message: "razorpay order id generated successfully",
-        order
+        order,
+        paymentStatus
     })
 })

--- a/src/utils/verifyPayment.js
+++ b/src/utils/verifyPayment.js
@@ -1,0 +1,20 @@
+import razorpay from "razorpay";
+import crypto from "crypto";
+import config from "../config/index.js";
+
+const verifyPayment = async (paymentData) => {
+    const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = paymentData;
+  
+    const generatedSignature = crypto
+      .createHmac("sha256", config.RAZORPAY_SECRET)
+      .update(`${razorpay_order_id}|${razorpay_payment_id}`)
+      .digest("hex");
+  
+    if (generatedSignature === razorpay_signature) {
+      return true;
+    } else {
+      throw new CustomError("Payment verification failed", 400);
+    }
+};
+
+export default verifyPayment


### PR DESCRIPTION
You can make a POST request to the /api/v1/payment endpoint with the following payload:
```json
{
  "amount": 500,
  "razorpay_payment_id": "<the payment ID you generated>",
  "razorpay_signature": "<generate a signature using your secret key>"
}
```

After making the request, you can check the response for the `order` and `paymentStatus` fields.